### PR TITLE
Update all npm dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "urijs": "^1.14.1",
-    "emailjs": "^0.3.12",
-    "fs-extra": "^0.16.3",
-    "handlebars": "^3.0.0",
-    "jquery": "^2.1.3",
-    "nightmare": "^1.8.2",
-    "nopt": "^3.0.1",
+    "emailjs": "^1.0.12",
+    "fs-extra": "^5.0.0",
+    "handlebars": "^4.0.11",
+    "nightmare": "^2.10.0",
+    "nopt": "^4.0.1",
     "octokit": "^0.10.4",
-    "phantomjs": "^1.9.16",
-    "superagent": "^0.21.0",
-    "winston": "0.8.3",
-    "winston-mail": "^0.3.1",
-    "weak" : "^1.0.0"
+    "phantomjs": "^2.1.7",
+    "superagent": "^3.8.2",
+    "winston": "^2.4.0",
+    "winston-mail": "^1.3.0"
   },
   "main": "./spork",
   "bin": {


### PR DESCRIPTION
&hellip;ie, [those reported by GH](https://github.com/w3c/spork/network/dependencies), plus a few others found by `npm-check` and `nsp`. Also, clean up `package.json` of unused modules.

After this, status of the project goes from [16 and 17 warnings](https://gist.github.com/tripu/96448944d9024c35de8638267e448d10) from `npm-check` and `nsp` respectively, to [3 and 3](https://gist.github.com/tripu/393bf7efa0ec3157643356afad03052e).

**NB:** these three modules I *think* are not being used (I could not find mentions to them in the code), so I removed them in this PR:

* `urijs`
* `jquery` (I see references to `$` though&nbsp;&mdash;&nbsp;is jQuery being imported okay?)
* `weak`

**Are they being used, and imported all right?**

Care to review, @darobin @plehegar @stevefaulkner&hellip;?

h/t @caribouW3